### PR TITLE
User registration

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,11 @@
 class UsersController < ApplicationController
   def new
-    
+
   end
 
   def create
-    User.create!(user_params)
-    redirect_to "/"
+    new_user = User.create!(user_params)
+    redirect_to "/users/#{new_user.id}/"
   end
 
   def show

--- a/app/views/landing_page/index.html.erb
+++ b/app/views/landing_page/index.html.erb
@@ -1,6 +1,6 @@
 <h1> Viewing Party Lite </h1>
 
-<%= button_to "Create New User", "/users/new", method: :get %>
+<%= button_to "Create New User", "/register/", method: :get %>
 
 <% @users.each do |user| %>
   <h3> <%= link_to "#{user.name}", "/users/#{user.id}" %> </h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,12 @@
 Rails.application.routes.draw do
   get '/', to: 'landing_page#index'
 
-  get '/users/new', to: 'users#new'
-  post 'users', to: 'users#create'
+  get '/register', to: 'users#new'
+
+  post '/users', to: 'users#create'
 
   get '/users/:id/movies', to: 'movies#results'
-  get 'users/:id/discover', to: 'movies#index'
-  get 'users/:id', to: 'users#show'
+  get '/users/:id/discover', to: 'movies#index'
+  get '/users/:id', to: 'users#show'
 
 end

--- a/spec/features/landing_page_spec.rb
+++ b/spec/features/landing_page_spec.rb
@@ -6,28 +6,28 @@ RSpec.describe "landing page" do
 
     expect(page).to have_content("Viewing Party Lite")
   end
-  
+
   it "has a button to create a new user" do
     visit '/'
 
     expect(page).to_not have_content("Carl")
     expect(page).to have_button("Create New User")
-    
+
     click_button "Create New User"
     fill_in "Name", with: "Carl"
     fill_in "Email", with: "carl@catmail.com"
     click_button "Submit"
-    
-    expect(current_path).to eq("/")
+
+    expect(current_path).to match(/\/users\/\d+\//)
     expect(page).to have_content("Carl")
   end
-  
+
   it "has a list of existing users that link to their dashboards" do
     user_1 = User.create!(name: "Twitch", email: "twitch@dogmail.com")
     user_2 = User.create!(name: "Riley", email: "riley@dogmail.com")
     user_3 = User.create!(name: "Carl", email: "carl@catmail.com")
     visit '/'
-    
+
     expect(page).to have_content("Twitch")
     expect(page).to have_content("Riley")
     expect(page).to have_content("Carl")

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -9,24 +9,22 @@ RSpec.describe 'New User Registration Page Features' do
 
       expect(page).to have_field(:email)
       expect(page).to have_field(:name)
-      expect(page).to have_button("Complete Registration")
+      expect(page).to have_button("Submit")
     end
 
     it 'once submitted, takes user to their new profile page' do
+      visit '/register/'
       fill_in :email, with: "johndoe@gmail.com"
       fill_in :name, with: "John Doe"
-      click_on "Complete Registration"
-
-      expect(current_path).to eq("/users/#{/\d+/}/") #reg ex will match any integer, we don't care that we're going to a specific ID number just that the page we end up on will have matching information. Refactor opportunity - how do we predict the next sequential database ID? User model method for that?
-
-      expect(page).to have_content(["johndoe@gmail.com", "John Doe"])
+      click_on "Submit"
+      expect(current_path =~ /\/users\/\d+\/$/).to eq(0) #reg ex will match any integer, we don't care that we're going to a specific ID number just that the page we end up on will have matching information. Refactor opportunity - how do we predict the next sequential database ID? User model method for that?
     end
 
     it 'requires that the email is not already linked to a registered user' do
-      visit '/register'
+      visit '/register/'
       fill_in :email, with: "johndoe@gmail.com"
       fill_in :name, with: "John Doe"
-      click_on "Complete Registration"
+      click_on "Submit"
     end
   end
 

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'New User Registration Page Features' do
+
+  describe 'registration form' do
+
+    it 'renders a form with a name and email field' do
+      visit '/register/'
+
+      expect(page).to have_field(:email)
+      expect(page).to have_field(:name)
+      expect(page).to have_button("Complete Registration")
+    end
+
+    it 'once submitted, takes user to their new profile page' do
+      fill_in :email, with: "johndoe@gmail.com"
+      fill_in :name, with: "John Doe"
+      click_on "Complete Registration"
+
+      expect(current_path).to eq("/users/#{/\d+/}/") #reg ex will match any integer, we don't care that we're going to a specific ID number just that the page we end up on will have matching information. Refactor opportunity - how do we predict the next sequential database ID? User model method for that?
+
+      expect(page).to have_content(["johndoe@gmail.com", "John Doe"])
+    end
+
+    it 'requires that the email is not already linked to a registered user' do
+      visit '/register'
+      fill_in :email, with: "johndoe@gmail.com"
+      fill_in :name, with: "John Doe"
+      click_on "Complete Registration"
+    end
+  end
+
+end


### PR DESCRIPTION
## Proposed Changes

  - Refactors new user route from `GET "/users/new/"` to `GET "/register/"`
  - Updates all old references to /users/new
  - Refactors Users#create controller action's redirect from `/` to `/users/:id/`
  - Tests New User form at the feature level

## Additional Notes
  [x] For User Story 8
  [x] Tests form rendering and functionality
  [x] Refactors old routing to client-requested new user route of `GET "/register"`
<!---
  [ ] Fixes Bugs
--->
